### PR TITLE
rebase_1.27: lint fixes

### DIFF
--- a/cmd/cluster-network-operator/main.go
+++ b/cmd/cluster-network-operator/main.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/operator"
@@ -21,8 +19,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 

--- a/pkg/controller/allowlist/allowlist_controller.go
+++ b/pkg/controller/allowlist/allowlist_controller.go
@@ -176,7 +176,7 @@ func createObject(ctx context.Context, client cnoclient.Client, obj *unstructure
 }
 
 func checkDsPodsReady(ctx context.Context, client cnoclient.Client) error {
-	return wait.Poll(time.Second, time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		podList, err := client.Default().Kubernetes().CoreV1().Pods(names.MULTUS_NAMESPACE).List(
 			ctx, metav1.ListOptions{LabelSelector: allowlistAnnotation})
 		if err != nil {

--- a/pkg/controller/operconfig/mtu_probe.go
+++ b/pkg/controller/operconfig/mtu_probe.go
@@ -66,7 +66,7 @@ func (r *ReconcileOperConfig) probeMTU(ctx context.Context, oc *operv1.Network, 
 	klog.Info("MTU prober deployed, waiting for result ConfigMap")
 
 	// wait up to 100 seconds for Job to report back.
-	err = wait.PollWithContext(ctx, 5*time.Second, 100*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 100*time.Second, false, func(ctx context.Context) (bool, error) {
 		var err error
 		mtu, err = r.readMTUConfigMap(ctx)
 		if err == nil {

--- a/pkg/controller/proxyconfig/controller.go
+++ b/pkg/controller/proxyconfig/controller.go
@@ -232,7 +232,7 @@ func (r *ReconcileProxyConfig) Reconcile(ctx context.Context, request reconcile.
 		}
 
 		// Create a configmap containing the merged proxy.trustedCA/system bundles.
-		//nolint:staticcheck // TODO:danehans maybe remove this line?
+		//nolint:staticcheck,wastedassign // TODO:danehans maybe remove this line?
 		trustBundle, err = r.mergeTrustBundlesToConfigMap(proxyData, systemData)
 		if err != nil {
 			log.Printf("Failed to merge trustedCA and system bundles for proxy '%s': %v", names.PROXY_CONFIG, err)

--- a/pkg/controller/signer/signer-controller.go
+++ b/pkg/controller/signer/signer-controller.go
@@ -134,7 +134,7 @@ func (r *ReconcileCSR) Reconcile(ctx context.Context, request reconcile.Request)
 			Reason:  "AutoApproved",
 			Message: "Automatically approved by " + signerName})
 		// Update status to "Approved"
-		//nolint:staticcheck
+		//nolint:staticcheck,wastedassign
 		csr, err = r.clientset.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, request.Name, csr, metav1.UpdateOptions{})
 		if err != nil {
 			log.Printf("Unable to approve certificate for %v and signer %v: %v", request.Name, signerName, err)


### PR DESCRIPTION
This was found from the following error in 'make golangci-lint' 

```
❯ make golangci-lint

pkg/controller/allowlist/allowlist_controller.go:179:9: SA1019: wait.Poll is deprecated: This method does not return errors from context, use PollWithContextTimeout. Note that the new method will no longer return ErrWaitTimeout and instead return errors defined by the context package. Will be removed in a future release. (staticcheck)
        return wait.Poll(time.Second, time.Minute, func() (done bool, err error) {
               ^
cmd/cluster-network-operator/main.go:24:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access. (staticcheck)
        rand.Seed(time.Now().UTC().UnixNano())
        ^
pkg/controller/operconfig/mtu_probe.go:69:8: SA1019: wait.PollWithContext is deprecated: This method does not return errors from context, use PollWithContextTimeout. Note that the new method will no longer return ErrWaitTimeout and instead return errors defined by the context package. Will be removed in a future release. (staticcheck)
        err = wait.PollWithContext(ctx, 5*time.Second, 100*time.Second, func(ctx context.Context) (bool, error) {
              ^
pkg/network/ovn_kubernetes.go:1103:9: SA1019: wait.PollImmediate is deprecated: This method does not return errors from context, use PollWithContextTimeout. Note that the new method will no longer return ErrWaitTimeout and instead return errors defined by the context package. Will be removed in a future release. (staticcheck)
        err := wait.PollImmediate(OVN_MASTER_DISCOVERY_POLL*time.Second, time.Duration(timeout)*time.Second, func() (bool, error) {
               ^
pkg/network/ovn_kubernetes.go:1122:5: SA1019: wait.ErrWaitTimeout is deprecated: This type will be made private in favor of Interrupted() for checking errors or ErrorInterrupted(err) for returning a wrapped error. (staticcheck)
        if wait.ErrWaitTimeout == err {
           ^
pkg/controller/proxyconfig/controller.go:236:3: assigned to trustBundle, but reassigned without using the value (wastedassign)
                trustBundle, err = r.mergeTrustBundlesToConfigMap(proxyData, systemData)
                ^
pkg/controller/signer/signer-controller.go:138:3: assigned to csr, but never used afterwards (wastedassign)
                csr, err = r.clientset.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, request.Name, csr, metav1.UpdateOptions{})
                ^
```